### PR TITLE
feat: update color theme to blue-indigo

### DIFF
--- a/src/components/Agents.tsx
+++ b/src/components/Agents.tsx
@@ -40,7 +40,7 @@ const defaultAgents = [
     icon: Plus,
     name: "Your Custom Agent",
     description: "Define skills, tools, and a base prompt to create your own specialist.",
-    color: "bg-[#da7756]/10 text-[#da7756]",
+    color: "bg-[#4f6ef5]/10 text-[#4f6ef5]",
     badge: "Custom",
     isCta: true,
   },
@@ -53,7 +53,7 @@ export default function Agents() {
         {/* Header */}
         <div className="grid lg:grid-cols-2 gap-12 items-end mb-16">
           <div>
-            <p className="text-[#da7756] font-semibold text-sm uppercase tracking-wide mb-3">
+            <p className="text-[#4f6ef5] font-semibold text-sm uppercase tracking-wide mb-3">
               Specialist agents
             </p>
             <h2 className="text-4xl font-bold text-gray-900">
@@ -75,7 +75,7 @@ export default function Agents() {
                 key={agent.name}
                 className={`group p-6 rounded-2xl border transition-all ${
                   agent.isCta
-                    ? "border-dashed border-[#da7756]/40 hover:border-[#da7756] bg-[#fdf8f6] cursor-pointer"
+                    ? "border-dashed border-[#4f6ef5]/40 hover:border-[#4f6ef5] bg-[#f0f4ff] cursor-pointer"
                     : "border-gray-100 hover:border-gray-200 hover:shadow-md bg-white"
                 }`}
               >
@@ -86,7 +86,7 @@ export default function Agents() {
                   <span
                     className={`text-xs font-semibold px-2.5 py-1 rounded-full ${
                       agent.badge === "Custom"
-                        ? "bg-[#da7756]/10 text-[#da7756]"
+                        ? "bg-[#4f6ef5]/10 text-[#4f6ef5]"
                         : "bg-gray-100 text-gray-500"
                     }`}
                   >
@@ -100,7 +100,7 @@ export default function Agents() {
                   {agent.description}
                 </p>
                 {agent.isCta && (
-                  <div className="mt-4 text-sm font-medium text-[#da7756] flex items-center gap-1 group-hover:gap-2 transition-all">
+                  <div className="mt-4 text-sm font-medium text-[#4f6ef5] flex items-center gap-1 group-hover:gap-2 transition-all">
                     Create custom agent →
                   </div>
                 )}
@@ -110,7 +110,7 @@ export default function Agents() {
         </div>
 
         {/* Runners banner */}
-        <div className="mt-16 rounded-2xl bg-gray-950 text-white p-8 lg:p-10 flex flex-col lg:flex-row items-start lg:items-center justify-between gap-8">
+        <div className="mt-16 rounded-2xl bg-[#0f172a] text-white p-8 lg:p-10 flex flex-col lg:flex-row items-start lg:items-center justify-between gap-8">
           <div>
             <h3 className="text-xl font-bold mb-2">Compatible with your favorite runners</h3>
             <p className="text-gray-400 text-sm max-w-lg">

--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -23,16 +23,16 @@ const platforms = [
 
 export default function Download() {
   return (
-    <section id="download" className="py-24 bg-gray-950 text-white relative overflow-hidden">
+    <section id="download" className="py-24 bg-[#0f172a] text-white relative overflow-hidden">
       {/* Background decoration */}
       <div className="absolute inset-0 pointer-events-none">
-        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[400px] bg-[#da7756]/10 rounded-full blur-3xl" />
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[400px] bg-[#4f6ef5]/10 rounded-full blur-3xl" />
       </div>
 
       <div className="relative max-w-4xl mx-auto px-6 lg:px-8 text-center">
         {/* Badge */}
         <div className="inline-flex items-center gap-2 bg-white/10 border border-white/10 text-sm font-medium px-3 py-1.5 rounded-full mb-8">
-          <DownloadIcon className="w-3.5 h-3.5 text-[#da7756]" />
+          <DownloadIcon className="w-3.5 h-3.5 text-[#4f6ef5]" />
           Free during beta
         </div>
 
@@ -67,7 +67,7 @@ export default function Download() {
         {/* Big primary CTA */}
         <a
           href="#"
-          className="inline-flex items-center gap-2 bg-[#da7756] hover:bg-[#c96644] text-white font-semibold px-8 py-4 rounded-full text-lg transition-colors shadow-lg shadow-[#da7756]/20"
+          className="inline-flex items-center gap-2 bg-[#4f6ef5] hover:bg-[#3d5ce3] text-white font-semibold px-8 py-4 rounded-full text-lg transition-colors shadow-lg shadow-[#4f6ef5]/20"
         >
           <DownloadIcon className="w-5 h-5" />
           Download for free
@@ -88,8 +88,8 @@ export default function Download() {
               <span className="ml-3 text-xs text-gray-600">AgentCenter — v0.1.0-beta</span>
             </div>
             <div className="aspect-video bg-gradient-to-br from-gray-900 to-gray-800 flex flex-col items-center justify-center gap-4 p-8">
-              <div className="w-14 h-14 rounded-2xl bg-[#da7756]/20 flex items-center justify-center">
-                <DownloadIcon className="w-7 h-7 text-[#da7756]" />
+              <div className="w-14 h-14 rounded-2xl bg-[#4f6ef5]/20 flex items-center justify-center">
+                <DownloadIcon className="w-7 h-7 text-[#4f6ef5]" />
               </div>
               <p className="text-sm text-gray-500 font-medium">App screenshot — coming soon</p>
               <p className="text-xs text-gray-700 text-center max-w-xs">

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -41,7 +41,7 @@ const features = [
     title: "Specialist Agents",
     description:
       "Use built-in agents for frontend, backend, testing, and code review — or configure your own with custom prompts and tools.",
-    color: "bg-[#da7756]/10 text-[#da7756]",
+    color: "bg-[#4f6ef5]/10 text-[#4f6ef5]",
   },
   {
     icon: PuzzleIcon,
@@ -58,7 +58,7 @@ export default function Features() {
       <div className="max-w-7xl mx-auto px-6 lg:px-8">
         {/* Header */}
         <div className="text-center max-w-2xl mx-auto mb-16">
-          <p className="text-[#da7756] font-semibold text-sm uppercase tracking-wide mb-3">
+          <p className="text-[#4f6ef5] font-semibold text-sm uppercase tracking-wide mb-3">
             Everything you need
           </p>
           <h2 className="text-4xl font-bold text-gray-900 mb-4">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,7 +14,7 @@ export default function Footer() {
           {/* Brand */}
           <div className="col-span-2">
             <div className="flex items-center gap-2 mb-4">
-              <div className="w-8 h-8 bg-[#da7756] rounded-lg flex items-center justify-center">
+              <div className="w-8 h-8 bg-[#4f6ef5] rounded-lg flex items-center justify-center">
                 <Bot className="w-5 h-5 text-white" />
               </div>
               <span className="font-semibold text-gray-900 text-lg">AgentCenter</span>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,24 +4,24 @@ import { ArrowRight, Github, Play } from "lucide-react";
 
 export default function Hero() {
   return (
-    <section className="relative pt-32 pb-20 overflow-hidden bg-[#fdf8f6]">
+    <section className="relative pt-32 pb-20 overflow-hidden bg-[#f0f4ff]">
       {/* Subtle background decoration */}
       <div className="absolute inset-0 pointer-events-none">
-        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[900px] h-[600px] bg-gradient-to-b from-[#da7756]/10 to-transparent rounded-full blur-3xl" />
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[900px] h-[600px] bg-gradient-to-b from-[#4f6ef5]/10 to-transparent rounded-full blur-3xl" />
       </div>
 
       <div className="relative max-w-7xl mx-auto px-6 lg:px-8">
         <div className="grid lg:grid-cols-2 gap-16 items-center">
           {/* Left: copy */}
           <div>
-            <div className="inline-flex items-center gap-2 bg-[#da7756]/10 text-[#da7756] text-sm font-medium px-3 py-1.5 rounded-full mb-6">
-              <span className="w-1.5 h-1.5 rounded-full bg-[#da7756] inline-block" />
+            <div className="inline-flex items-center gap-2 bg-[#4f6ef5]/10 text-[#4f6ef5] text-sm font-medium px-3 py-1.5 rounded-full mb-6">
+              <span className="w-1.5 h-1.5 rounded-full bg-[#4f6ef5] inline-block" />
               Now in beta — download free
             </div>
 
             <h1 className="text-5xl lg:text-6xl font-bold leading-tight tracking-tight text-gray-900 text-balance mb-6">
               Your command center for{" "}
-              <span className="text-[#da7756]">AI development agents</span>
+              <span className="text-[#4f6ef5]">AI development agents</span>
             </h1>
 
             <p className="text-lg text-gray-600 leading-relaxed mb-10 max-w-xl">
@@ -33,7 +33,7 @@ export default function Hero() {
             <div className="flex flex-wrap gap-4">
               <a
                 href="#download"
-                className="inline-flex items-center gap-2 bg-[#da7756] hover:bg-[#c96644] text-white font-semibold px-6 py-3.5 rounded-full transition-colors shadow-sm"
+                className="inline-flex items-center gap-2 bg-[#4f6ef5] hover:bg-[#3d5ce3] text-white font-semibold px-6 py-3.5 rounded-full transition-colors shadow-sm"
               >
                 Download AgentCenter
                 <ArrowRight className="w-4 h-4" />
@@ -61,9 +61,9 @@ export default function Hero() {
           <div className="relative">
             <div className="rounded-2xl overflow-hidden border border-gray-200 shadow-2xl bg-white">
               {/* Placeholder for product screenshot */}
-              <div className="aspect-[4/3] bg-gradient-to-br from-gray-50 to-gray-100 flex flex-col items-center justify-center gap-4 p-8">
-                <div className="w-16 h-16 rounded-2xl bg-[#da7756]/10 flex items-center justify-center">
-                  <svg className="w-8 h-8 text-[#da7756]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <div className="aspect-[4/3] bg-gradient-to-br from-[#0f172a] to-[#1e293b] flex flex-col items-center justify-center gap-4 p-8">
+                <div className="w-16 h-16 rounded-2xl bg-[#4f6ef5]/10 flex items-center justify-center">
+                  <svg className="w-8 h-8 text-[#4f6ef5]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                   </svg>
                 </div>

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -31,11 +31,11 @@ const steps = [
 
 export default function HowItWorks() {
   return (
-    <section id="how-it-works" className="py-24 bg-[#fdf8f6]">
+    <section id="how-it-works" className="py-24 bg-[#f0f4ff]">
       <div className="max-w-7xl mx-auto px-6 lg:px-8">
         {/* Header */}
         <div className="text-center max-w-2xl mx-auto mb-20">
-          <p className="text-[#da7756] font-semibold text-sm uppercase tracking-wide mb-3">
+          <p className="text-[#4f6ef5] font-semibold text-sm uppercase tracking-wide mb-3">
             How it works
           </p>
           <h2 className="text-4xl font-bold text-gray-900 mb-4">
@@ -77,9 +77,9 @@ export default function HowItWorks() {
                     <span className="w-2.5 h-2.5 rounded-full bg-green-300" />
                     <span className="ml-3 text-xs text-gray-400">{step.imageAlt}</span>
                   </div>
-                  <div className="aspect-video bg-gradient-to-br from-gray-50 to-gray-100 flex flex-col items-center justify-center gap-3 p-8">
-                    <div className="w-12 h-12 rounded-xl bg-[#da7756]/10 flex items-center justify-center">
-                      <svg className="w-6 h-6 text-[#da7756]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <div className="aspect-video bg-gradient-to-br from-[#0f172a] to-[#1e293b] flex flex-col items-center justify-center gap-3 p-8">
+                    <div className="w-12 h-12 rounded-xl bg-[#4f6ef5]/10 flex items-center justify-center">
+                      <svg className="w-6 h-6 text-[#4f6ef5]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                       </svg>
                     </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -18,7 +18,7 @@ export default function Navbar() {
       <nav className="max-w-7xl mx-auto px-6 lg:px-8 h-16 flex items-center justify-between">
         {/* Logo */}
         <a href="#" className="flex items-center gap-2 font-semibold text-gray-900">
-          <div className="w-8 h-8 bg-[#da7756] rounded-lg flex items-center justify-center">
+          <div className="w-8 h-8 bg-[#4f6ef5] rounded-lg flex items-center justify-center">
             <Bot className="w-5 h-5 text-white" />
           </div>
           <span className="text-lg">AgentCenter</span>
@@ -48,7 +48,7 @@ export default function Navbar() {
           </a>
           <a
             href="#download"
-            className="bg-[#da7756] hover:bg-[#c96644] text-white text-sm font-medium px-4 py-2 rounded-full transition-colors"
+            className="bg-[#4f6ef5] hover:bg-[#3d5ce3] text-white text-sm font-medium px-4 py-2 rounded-full transition-colors"
           >
             Download
           </a>
@@ -82,7 +82,7 @@ export default function Navbar() {
             <li>
               <a
                 href="#download"
-                className="inline-block bg-[#da7756] text-white font-medium px-4 py-2 rounded-full text-sm"
+                className="inline-block bg-[#4f6ef5] text-white font-medium px-4 py-2 rounded-full text-sm"
                 onClick={() => setMobileOpen(false)}
               >
                 Download

--- a/src/components/TokenControl.tsx
+++ b/src/components/TokenControl.tsx
@@ -25,7 +25,7 @@ const benefits = [
 
 export default function TokenControl() {
   return (
-    <section className="py-24 bg-[#fdf8f6]">
+    <section className="py-24 bg-[#f0f4ff]">
       <div className="max-w-7xl mx-auto px-6 lg:px-8">
         <div className="grid lg:grid-cols-2 gap-16 items-center">
           {/* Left: image placeholder */}
@@ -40,7 +40,7 @@ export default function TokenControl() {
               </div>
 
               {/* Placeholder content that mimics a cost dashboard */}
-              <div className="p-6 bg-gradient-to-br from-gray-50 to-white">
+              <div className="p-6 bg-gradient-to-br from-[#0f172a] to-[#1e293b]">
                 {/* Fake chart area */}
                 <div className="mb-4 flex items-end gap-2 h-24">
                   {[40, 65, 50, 80, 55, 70, 45, 90, 60, 75, 50, 85].map((h, i) => (
@@ -50,7 +50,7 @@ export default function TokenControl() {
                       style={{
                         height: `${h}%`,
                         background: i === 11
-                          ? "#da7756"
+                          ? "#4f6ef5"
                           : i % 3 === 0
                           ? "#e5e7eb"
                           : "#f3f4f6",
@@ -96,7 +96,7 @@ export default function TokenControl() {
 
           {/* Right: copy */}
           <div>
-            <p className="text-[#da7756] font-semibold text-sm uppercase tracking-wide mb-3">
+            <p className="text-[#4f6ef5] font-semibold text-sm uppercase tracking-wide mb-3">
               Cost control
             </p>
             <h2 className="text-4xl font-bold text-gray-900 mb-4">
@@ -113,8 +113,8 @@ export default function TokenControl() {
                 const Icon = b.icon;
                 return (
                   <li key={b.title} className="flex items-start gap-4">
-                    <div className="w-10 h-10 rounded-xl bg-[#da7756]/10 flex items-center justify-center shrink-0 mt-0.5">
-                      <Icon className="w-5 h-5 text-[#da7756]" />
+                    <div className="w-10 h-10 rounded-xl bg-[#4f6ef5]/10 flex items-center justify-center shrink-0 mt-0.5">
+                      <Icon className="w-5 h-5 text-[#4f6ef5]" />
                     </div>
                     <div>
                       <p className="font-semibold text-gray-900 mb-0.5">{b.title}</p>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,16 +12,16 @@ const config: Config = {
         background: "var(--background)",
         foreground: "var(--foreground)",
         primary: {
-          DEFAULT: "#da7756", // Warm orange like Claude's Cowork
+          DEFAULT: "#4f6ef5", // Blue-indigo
           foreground: "#ffffff",
         },
         muted: {
-          DEFAULT: "#f4f4f4",
+          DEFAULT: "#f0f4ff",
           foreground: "#666666",
         },
         accent: {
-          DEFAULT: "#f0f0f0",
-          foreground: "#333333",
+          DEFAULT: "#e8eeff",
+          foreground: "#1e3a8a",
         }
       },
       fontFamily: {


### PR DESCRIPTION
## Summary

- Replace warm orange (`#da7756`) with blue-indigo (`#4f6ef5`) across all components
- Light section backgrounds updated from `#fdf8f6` → `#f0f4ff`
- Screenshot placeholders now use dark navy (`#0f172a`/`#1e293b`) to match the real app's dark UI
- Hover states, icon backgrounds, card borders, badges all updated consistently
- Build passes with zero errors

## How to test

- [ ] `npm run dev` → open http://localhost:3000
- [ ] Verify all orange is gone — everything should use blue/indigo tones
- [ ] Check dark sections (Download, Agents banner, placeholder UIs) use navy background

🤖 Generated with [Claude Code](https://claude.com/claude-code)