### PR TITLE
feat: dynamic GitHub release download buttons

### DIFF
--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -1,27 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { Download as DownloadIcon, Apple, Monitor, Terminal } from "lucide-react";
 
-const platforms = [
-  {
-    icon: Apple,
-    label: "macOS",
-    sublabel: "Apple Silicon & Intel",
-    href: "#",
-  },
-  {
-    icon: Monitor,
-    label: "Windows",
-    sublabel: "Windows 10 / 11",
-    href: "#",
-  },
-  {
-    icon: Terminal,
-    label: "Linux",
-    sublabel: ".deb · .rpm · AppImage",
-    href: "#",
-  },
-];
+interface ReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+interface GitHubRelease {
+  tag_name: string;
+  assets: ReleaseAsset[];
+}
+
+interface DownloadLinks {
+  version: string;
+  arm64: string | null;
+  x86: string | null;
+}
+
+const GITHUB_REPO = "svlucero/AgentCenter";
+
+function useGitHubRelease() {
+  const [release, setRelease] = useState<DownloadLinks>({
+    version: "...",
+    arm64: null,
+    x86: null,
+  });
+
+  useEffect(() => {
+    async function fetchRelease() {
+      try {
+        const res = await fetch(
+          `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`
+        );
+        if (!res.ok) return;
+        const data: GitHubRelease = await res.json();
+
+        const arm64 = data.assets.find(
+          (a) => a.name.includes("aarch64") && a.name.endsWith(".dmg")
+        );
+        const x86 = data.assets.find(
+          (a) => a.name.includes("x86_64") && a.name.endsWith(".dmg")
+        );
+
+        setRelease({
+          version: data.tag_name,
+          arm64: arm64?.browser_download_url ?? null,
+          x86: x86?.browser_download_url ?? null,
+        });
+      } catch {
+        // silently fail — buttons remain disabled
+      }
+    }
+
+    fetchRelease();
+  }, []);
+
+  return release;
+}
 
 export default function Download() {
+  const { version, arm64, x86 } = useGitHubRelease();
+
+  const isLoading = version === "...";
+  const primaryHref = arm64 ?? x86 ?? "#";
+  const primaryDisabled = !arm64 && !x86;
+
   return (
     <section id="download" className="py-24 bg-[#0f172a] text-white relative overflow-hidden">
       {/* Background decoration */}
@@ -39,42 +84,106 @@ export default function Download() {
         <h2 className="text-5xl font-bold mb-6 tracking-tight">
           Start shipping with AI agents today
         </h2>
-        <p className="text-gray-400 text-lg mb-12 max-w-xl mx-auto leading-relaxed">
+        <p className="text-gray-400 text-lg mb-4 max-w-xl mx-auto leading-relaxed">
           Download AgentCenter for free and connect your first repository in under
           5 minutes. No credit card required during beta.
         </p>
 
-        {/* Platform buttons */}
-        <div className="flex flex-wrap justify-center gap-4 mb-16">
-          {platforms.map((p) => {
-            const Icon = p.icon;
-            return (
-              <a
-                key={p.label}
-                href={p.href}
-                className="group flex items-center gap-3 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 text-white px-5 py-3.5 rounded-xl transition-all"
-              >
-                <Icon className="w-5 h-5 text-gray-300 group-hover:text-white transition-colors" />
-                <div className="text-left">
-                  <p className="text-sm font-semibold">{p.label}</p>
-                  <p className="text-xs text-gray-500">{p.sublabel}</p>
-                </div>
-              </a>
-            );
-          })}
+        {/* Version badge */}
+        <div className="inline-flex items-center gap-1.5 text-xs text-gray-500 mb-10">
+          <span className="w-1.5 h-1.5 rounded-full bg-green-400 inline-block" />
+          Latest release:&nbsp;
+          <span className={`font-mono font-medium text-gray-400 ${isLoading ? "animate-pulse" : ""}`}>
+            {version}
+          </span>
+        </div>
+
+        {/* macOS download buttons */}
+        <div className="flex flex-wrap justify-center gap-4 mb-8">
+          {/* Apple Silicon */}
+          <a
+            id="dl-arm64"
+            href={arm64 ?? "#"}
+            aria-disabled={!arm64}
+            className={`group flex items-center gap-3 border px-5 py-3.5 rounded-xl transition-all
+              ${arm64
+                ? "bg-white/5 hover:bg-white/10 border-white/10 hover:border-white/20 text-white cursor-pointer"
+                : "bg-white/[0.02] border-white/5 text-gray-600 cursor-not-allowed"
+              }`}
+            onClick={!arm64 ? (e) => e.preventDefault() : undefined}
+          >
+            <Apple className={`w-5 h-5 transition-colors ${arm64 ? "text-gray-300 group-hover:text-white" : "text-gray-700"}`} />
+            <div className="text-left">
+              <p className="text-sm font-semibold">macOS — Apple Silicon</p>
+              <p className="text-xs text-gray-500">M1 / M2 / M3 · .dmg</p>
+            </div>
+          </a>
+
+          {/* Intel */}
+          <a
+            id="dl-x86"
+            href={x86 ?? "#"}
+            aria-disabled={!x86}
+            className={`group flex items-center gap-3 border px-5 py-3.5 rounded-xl transition-all
+              ${x86
+                ? "bg-white/5 hover:bg-white/10 border-white/10 hover:border-white/20 text-white cursor-pointer"
+                : "bg-white/[0.02] border-white/5 text-gray-600 cursor-not-allowed"
+              }`}
+            onClick={!x86 ? (e) => e.preventDefault() : undefined}
+          >
+            <Apple className={`w-5 h-5 transition-colors ${x86 ? "text-gray-300 group-hover:text-white" : "text-gray-700"}`} />
+            <div className="text-left">
+              <p className="text-sm font-semibold">macOS — Intel</p>
+              <p className="text-xs text-gray-500">x86_64 · .dmg</p>
+            </div>
+          </a>
+
+          {/* Windows — coming soon */}
+          <a
+            href="#"
+            aria-disabled
+            className="group flex items-center gap-3 bg-white/[0.02] border border-white/5 text-gray-600 px-5 py-3.5 rounded-xl cursor-not-allowed"
+            onClick={(e) => e.preventDefault()}
+          >
+            <Monitor className="w-5 h-5 text-gray-700" />
+            <div className="text-left">
+              <p className="text-sm font-semibold">Windows</p>
+              <p className="text-xs text-gray-700">Coming soon</p>
+            </div>
+          </a>
+
+          {/* Linux — coming soon */}
+          <a
+            href="#"
+            aria-disabled
+            className="group flex items-center gap-3 bg-white/[0.02] border border-white/5 text-gray-600 px-5 py-3.5 rounded-xl cursor-not-allowed"
+            onClick={(e) => e.preventDefault()}
+          >
+            <Terminal className="w-5 h-5 text-gray-700" />
+            <div className="text-left">
+              <p className="text-sm font-semibold">Linux</p>
+              <p className="text-xs text-gray-700">Coming soon</p>
+            </div>
+          </a>
         </div>
 
         {/* Big primary CTA */}
         <a
-          href="#"
-          className="inline-flex items-center gap-2 bg-[#6d28d9] hover:bg-[#5b21b6] text-white font-semibold px-8 py-4 rounded-full text-lg transition-colors shadow-lg shadow-[#6d28d9]/20"
+          href={primaryHref}
+          aria-disabled={primaryDisabled}
+          className={`inline-flex items-center gap-2 font-semibold px-8 py-4 rounded-full text-lg transition-colors shadow-lg shadow-[#6d28d9]/20
+            ${primaryDisabled
+              ? "bg-[#6d28d9]/40 text-white/40 cursor-not-allowed"
+              : "bg-[#6d28d9] hover:bg-[#5b21b6] text-white"
+            }`}
+          onClick={primaryDisabled ? (e) => e.preventDefault() : undefined}
         >
           <DownloadIcon className="w-5 h-5" />
           Download for free
         </a>
 
         <p className="mt-4 text-sm text-gray-600">
-          Available for macOS · Windows · Linux
+          macOS · Windows (soon) · Linux (soon)
         </p>
 
         {/* Divider */}
@@ -85,7 +194,12 @@ export default function Download() {
               <span className="w-2.5 h-2.5 rounded-full bg-red-400/50" />
               <span className="w-2.5 h-2.5 rounded-full bg-yellow-400/50" />
               <span className="w-2.5 h-2.5 rounded-full bg-green-400/50" />
-              <span className="ml-3 text-xs text-gray-600">AgentCenter — v0.1.0-beta</span>
+              <span className="ml-3 text-xs text-gray-600">
+                AgentCenter —{" "}
+                <span id="release-version" className={`font-mono ${isLoading ? "animate-pulse" : ""}`}>
+                  {version}
+                </span>
+              </span>
             </div>
             <div className="aspect-video bg-gradient-to-br from-gray-900 to-gray-800 flex flex-col items-center justify-center gap-4 p-8">
               <div className="w-14 h-14 rounded-2xl bg-[#6d28d9]/20 flex items-center justify-center">


### PR DESCRIPTION
## Summary

- Replaces static `href="#"` download links with live data fetched from the GitHub Releases API
- Adds a `useGitHubRelease` hook that calls `https://api.github.com/repos/svlucero/AgentCenter/releases/latest` on mount
- Splits the macOS button into two variants: **Apple Silicon** (`aarch64.dmg`) and **Intel** (`x86_64.dmg`)
- Displays the live version tag (`tag_name`) in both the version badge and the mock window title bar — auto-updates with each new release, no HTML edits needed
- Windows and Linux buttons are shown as "coming soon" (no assets available yet)
- Primary CTA targets Apple Silicon with graceful fallback to Intel

## How to test

- [ ] Open the Download section — version badge should show the latest tag (e.g. `v0.1.0`)
- [ ] Click "macOS — Apple Silicon" — should trigger a `.dmg` download for `aarch64`
- [ ] Click "macOS — Intel" — should trigger a `.dmg` download for `x86_64`
- [ ] Windows and Linux buttons should be visually disabled and non-clickable
- [ ] Publish a new GitHub release and reload the page — version and links update automatically

## Notes

Uses the unauthenticated GitHub REST API (60 req/hour per IP, sufficient for a landing page).

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)